### PR TITLE
Added functionality to clear cache for module item for which comment is hooked

### DIFF
--- a/src/modules/EZComments/lib/EZComments/Api/Admin.php
+++ b/src/modules/EZComments/lib/EZComments/Api/Admin.php
@@ -107,6 +107,9 @@ class EZComments_Api_Admin extends Zikula_AbstractApi
             return LogUtil::registerError($this->__('Error! Deletion attempt failed.'));
         }
 
+        // clear respective cache
+        ModUtil::apiFunc('EZComments', 'user', 'clearItemCache', $item);
+
         // Let the calling process know that we have finished successfully
         return true;
     }
@@ -157,6 +160,9 @@ class EZComments_Api_Admin extends Zikula_AbstractApi
         if (!DBUtil::updateObject($args, 'EZComments')) {
             return LogUtil::registerError($this->__('Error! Update attempt failed.'));
         }
+
+        // clear respective cache
+        ModUtil::apiFunc('EZComments', 'user', 'clearItemCache', $item);
 
         // Let the calling process know that we have finished successfully
         return true;
@@ -241,6 +247,9 @@ class EZComments_Api_Admin extends Zikula_AbstractApi
         if (!$securityCheck) {
             return LogUtil::registerPermissionError(ModUtil::url('EZComments', 'admin', 'main'));
         }
+
+        // clear respective cache
+        ModUtil::apiFunc('EZComments', 'user', 'clearItemCache', $item);
 
         // Save old status
         $oldStatus = $item['status'];

--- a/src/modules/EZComments/lib/EZComments/Api/User.php
+++ b/src/modules/EZComments/lib/EZComments/Api/User.php
@@ -290,6 +290,9 @@ class EZComments_Api_User extends Zikula_AbstractApi
             return LogUtil::registerError($this->__('Error! Creation attempt failed.'));
         }
 
+        // clear respective cache
+        ModUtil::apiFunc('EZComments', 'user', 'clearItemCache', $newcomment);
+
         // set an approriate status/errormsg
         switch ($maxstatus)
         {
@@ -836,4 +839,23 @@ class EZComments_Api_User extends Zikula_AbstractApi
 
         return $items;
     }
+
+    /**
+     * Clear cache for given item. Actually clears cache for calling module object Id (npetkov)
+     */
+    public function clearItemCache($commentitem)
+    {
+        $result = false;
+        
+        // this a little bit ugly solution (to check for module name, but cannot find better for now)
+        // will attempt to "standartize" calling: name of module user api method
+        if ($commentitem['modname'] == 'News') {
+             $result = ModUtil::apiFunc('News', 'user', 'clearItemCache', $commentitem['objectid']);
+        } else if ($commentitem['modname'] == 'Downloads') {
+             $result = ModUtil::apiFunc('Downloads', 'user', 'clearItemCache', $commentitem['objectid']);
+        }
+        
+        return $result;
+    }
+
 }

--- a/src/modules/EZComments/lib/EZComments/Controller/Admin.php
+++ b/src/modules/EZComments/lib/EZComments/Controller/Admin.php
@@ -40,6 +40,8 @@ class EZComments_Controller_Admin extends Zikula_AbstractController
 
         $startnum = FormUtil::getPassedValue('startnum', null, 'GETPOST');
 
+        $this->view->setCaching(false); // we are at admin side, don''t know way, but otherwise changes not seen
+
         // assign the module vars
         $this->view->assign(ModUtil::getVar('EZComments'));
 

--- a/src/modules/EZComments/lib/EZComments/Controller/User.php
+++ b/src/modules/EZComments/lib/EZComments/Controller/User.php
@@ -78,6 +78,8 @@ class EZComments_Controller_User extends Zikula_AbstractController
 
         $numberOfItems = ModUtil::apiFunc('EZComments', 'user', 'countitems', $params);
 
+        $this->view->setCaching(false); // don't use caching, not so important as only registered users can see this page
+
         // assign collected data to the template
         $this->view->assign(ModUtil::getVar('EZComments'))
                    ->assign('items',  $items)
@@ -306,8 +308,11 @@ class EZComments_Controller_User extends Zikula_AbstractController
                                  'anonmail'    => $anonmail,
                                  'anonwebsite' => $anonwebsite));
 
-        // redirect if it was not successful
-        if (!$id) {
+        if ($id) {
+            // clear respective cache
+            ModUtil::apiFunc('EZComments', 'user', 'clearItemCache', array('id' => $id, 'modname' => $mod, 'objectid' => $objectid, 'url' => $url));
+        } else {
+            // redirect if it was not successful
             SessionUtil::setVar('ezcomment', $ezcomment);
             System::redirect($redirect."#commentform_{$mod}_{$objectid}");
         }
@@ -420,7 +425,7 @@ class EZComments_Controller_User extends Zikula_AbstractController
                    ->assign('itemurl'     , $itemUrl);
 
         // display the feed and notify the core that we're done
-        $this->view->display("ezcomments_user_$feedtype.tpl.tpl");
+        $this->view->display("ezcomments_user_$feedtype.tpl");
         return true;
     }
 


### PR DESCRIPTION
Now comments can work when caching is enabled.
Have to include respective clear cache module function into clearItemCache user api function.
For now supported News and Downloads modules.
