### PR TITLE
Pass uid as parameter and strip domain in list comments function

### DIFF
--- a/lib/EZComments/Controller/User.php
+++ b/lib/EZComments/Controller/User.php
@@ -55,11 +55,11 @@ class EZComments_Controller_User extends Zikula_AbstractController
         // loop through each item adding the relevant links
         foreach ($items as $k => $item)
         {
-        // strip domain (if mobile/desktop differ)
-        $urlparts = parse_url($item['url']);
-        $item['url'] = $urlparts['path'].'?'.$urlparts['query'];
+            // strip domain (if mobile/desktop differ)
+            $urlparts = parse_url($item['url']);
+            $item['url'] = $urlparts['path'].'?'.$urlparts['query'];
 
-        $options   = array();
+            $options   = array();
             $options[] = array('url'   => $item['url'] . '#comment' . $item['id'],
                                'image' => 'kview.png',
                                'title' => $this->__('View'));


### PR DESCRIPTION
1. Pass user id as parameter in list comments per user function.
   This change permits to view all comments from given user. Then if we like, we can add a link in user profile view window (for this purpose we have to change one tpl file in profile module).
2. Strip domain from url.
   This is useful for proper view in cases when mobile site differs from desktop one (www. / m.).

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| Refs tickets |  |
| License | MIT |
| Doc PR |  |
